### PR TITLE
fix(github-actions): accept immutable OIDC subject claims

### DIFF
--- a/modules/account-modules/github-actions-support/github-roles.tf
+++ b/modules/account-modules/github-actions-support/github-roles.tf
@@ -25,7 +25,8 @@ data "aws_iam_policy_document" "github_actions_assume_role" {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
       values = [
-        "repo:transactrx/*:${var.branch_name}*"
+        "repo:transactrx/*:${var.branch_name}*",              # legacy mutable subject (repos created before 2026-04-23)
+        "repo:transactrx@3543463/*:${var.branch_name}*"       # immutable subject (repos created after; 3543463 = transactrx org id, constant)
       ]
     }
   }


### PR DESCRIPTION
## Problem
GitHub now issues OIDC tokens with **immutable subject claims** for repos created after 2026-04-23 ([changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)). The subject embeds org/repo IDs:

```
repo:transactrx@3543463/<repo>@<repoId>:environment:<branch>
```

The existing single `sub` pattern `repo:transactrx/*:${var.branch_name}*` starts with `repo:transactrx/` and never matches the new `repo:transactrx@3543463/...` format, so `sts:AssumeRoleWithWebIdentity` fails with **Not authorized** for any repo created after the rollout (first hit: `masterPatientIndexClinicalPlusFeeder`).

## Fix
Add a second `sub` pattern anchored on the **constant** transactrx org id (`3543463`, confirmed via `gh api orgs/transactrx --jq .id`). The `*` after the `/` absorbs the per-repo repo name + repo id + environment segment, so this one line covers **every** future repo with no per-repo maintenance.

- **Non-breaking:** legacy pattern retained → all pre-2026-04-23 repos keep working.
- **Shared module:** every account/root consuming `github-actions-support` (all pinned `?ref=master`) picks this up on next `init -upgrade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)