### PR TITLE
Add moved blocks so us-west-2 can return from its vendored github-actions-support copy

### DIFF
--- a/modules/account-modules/github-actions-support/moved-blocks.tf
+++ b/modules/account-modules/github-actions-support/moved-blocks.tf
@@ -1,0 +1,59 @@
+# State migration for consumers of the vendored copy of this module
+# (rasdataservices_aws resources/us-west-2/modules/github-actions-support),
+# which renamed these resources to snake_case. The moved blocks map the
+# vendored addresses back to this module's addresses so switching the module
+# source back to this shared module is a pure rename — no destroy/recreate of
+# the Terraform state bucket, lock table, or IAM resources.
+#
+# For consumers that always used this module, none of the "from" addresses
+# exist in state, so every block is a no-op.
+
+moved {
+  from = aws_s3_bucket.terraform_bucket
+  to   = aws_s3_bucket.terraformBucket
+}
+
+moved {
+  from = aws_s3_bucket_versioning.terraform_bucket_versioning
+  to   = aws_s3_bucket_versioning.terraformBucketVersioning
+}
+
+moved {
+  from = aws_s3_bucket_ownership_controls.terraform_bucket_ownership
+  to   = aws_s3_bucket_ownership_controls.terraformBucketOwnershipControls
+}
+
+moved {
+  from = aws_s3_bucket_acl.terraform_bucket_acl
+  to   = aws_s3_bucket_acl.terraformBucketACL
+}
+
+moved {
+  from = aws_dynamodb_table.terraform_lock_table
+  to   = aws_dynamodb_table.terraformLockTable
+}
+
+moved {
+  from = aws_iam_policy.terraform_s3_policy
+  to   = aws_iam_policy.terraformS3Policy
+}
+
+moved {
+  from = aws_iam_policy.terraform_lock_policy
+  to   = aws_iam_policy.terraformLockPolicy
+}
+
+moved {
+  from = aws_ssm_parameter.private_subnet_ids
+  to   = aws_ssm_parameter.private-subnet-ids
+}
+
+moved {
+  from = aws_ssm_parameter.vpc_id
+  to   = aws_ssm_parameter.vpc-id
+}
+
+moved {
+  from = aws_iam_openid_connect_provider.github_identity_provider
+  to   = aws_iam_openid_connect_provider.githubIdentityProvider
+}


### PR DESCRIPTION
## Why

`rasdataservices_aws` `resources/us-west-2` uses a local vendored copy of `modules/account-modules/github-actions-support` (created when multi-region support was added). The vendored copy renamed ~10 resources to snake_case, so pointing west back at this shared module would otherwise plan a destroy/recreate of the Terraform **state bucket**, **lock table**, IAM policies, and SSM parameters.

## What

Adds `moved-blocks.tf` mapping the vendored snake_case addresses to this module's addresses. With this merged, switching the west root's module `source` back to this shared module becomes a pure in-state rename.

**Backwards compatible:** for every existing consumer of this module, the `from` addresses don't exist in state, so all blocks are no-ops (verified: `moved` blocks are ignored when the source address is absent).

No resource, variable, or output changes. The shared module already supports west's needs (`region` name suffix, `identity_provider_arn` passthrough, immutable OIDC subject fix from #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)