### PR TITLE
fix(github-actions-support): grant CloudWatch alarm tag APIs to deploy role

### DIFF
--- a/modules/account-modules/github-actions-support/permissions.tf
+++ b/modules/account-modules/github-actions-support/permissions.tf
@@ -41,7 +41,15 @@ data "aws_iam_policy_document" "allow_ecs_autoscaling_config" {
       "cloudwatch:DeleteAlarms",
       "cloudwatch:DescribeAlarms",
       "cloudwatch:GetMetricStatistics",
-      "cloudwatch:SetAlarmState"
+      "cloudwatch:SetAlarmState",
+      # AWS provider v5+ manages tags on every taggable resource: it calls
+      # ListTagsForResource after creating/refreshing an aws_cloudwatch_metric_alarm
+      # and Tag/UntagResource to reconcile tags on later applies. Without these,
+      # any workflow whose terraform manages a CloudWatch alarm fails with
+      # AccessDenied on the post-create tag read.
+      "cloudwatch:ListTagsForResource",
+      "cloudwatch:TagResource",
+      "cloudwatch:UntagResource"
     ]
     resources = ["*"]
   }
@@ -452,8 +460,8 @@ data "aws_iam_policy_document" "allow-lambda-invoke" {
   version = "2012-10-17"
 
   statement {
-    sid     = "AllowInvokeAlbSequenceLambdasAllEnv"
-    effect  = "Allow"
+    sid    = "AllowInvokeAlbSequenceLambdasAllEnv"
+    effect = "Allow"
     actions = [
       "lambda:*"
     ]
@@ -504,7 +512,7 @@ data "aws_iam_policy_document" "allow_globalaccelerator_permissions" {
 resource "aws_iam_role_policy" "allow_globalaccelerator_permissions" {
   name   = "allow-globalaccelerator-permissions"
   policy = data.aws_iam_policy_document.allow_globalaccelerator_permissions.json
-  role   = aws_iam_role.github_actions.name  # Replace with your role name
+  role   = aws_iam_role.github_actions.name # Replace with your role name
 }
 
 data "aws_iam_policy_document" "allow_sqs_actions" {


### PR DESCRIPTION
## Problem

The `allow_autoscaling_config` policy grants `cloudwatch:PutMetricAlarm` but none of the CloudWatch tag APIs. AWS provider v5+ treats tags as part of every taggable resource's state: after creating (and on every refresh of) an `aws_cloudwatch_metric_alarm`, it calls `ListTagsForResource`, and it needs `TagResource`/`UntagResource` to reconcile tags (including account `default_tags`) on later applies.

Result: any service workflow whose terraform manages a CloudWatch alarm fails its deploy with `AccessDenied: ListTagsForResource`. First hit by eventsCollector's new burst step-scaling alarm (2026-07-22, both dev deploy runs failed at `terraform apply`).

## Change

Add three actions to the `allow_ecs_autoscaling_config` policy document:

- `cloudwatch:ListTagsForResource`
- `cloudwatch:TagResource`
- `cloudwatch:UntagResource`

Statement scope unchanged (`Resource: *`, same as the existing alarm actions). `terraform validate` passes.

## Drift note (why this should merge soon)

To unblock the eventsCollector deploy, the four rasdataservices deploy roles (`rasdataservices-{dev,prod}-github-actions[-west]`) were **live-patched** on 2026-07-22 with exactly these three actions. The patch content is byte-identical to this module change, so the next account-level apply after this merges converges cleanly and removes the drift — but until then, a re-apply of the module would revert the live patches and break eventsCollector deploys again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)